### PR TITLE
ISS-1472115: Crash fix iOS 17

### DIFF
--- a/razorpay-customui-pod.podspec
+++ b/razorpay-customui-pod.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'razorpay-customui-pod'
-  s.version          = '2.1.1'
+  s.version          = '2.1.2'
   s.summary          = "CocoaPod implementation of Razorpay's Custom Payment SDK"
 
   s.description      = <<-DESC
@@ -31,9 +31,7 @@ helps businesses accepts online payments via Credit Card, Debit Card, Net bankin
   s.platform     = :ios, '11.0'
   
   s.vendored_frameworks = 'Pod/RazorpayCustom.xcframework'
-  s.dependency 'razorpay-core-pod'
-  
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  s.dependency 'razorpay-core-pod', '>= 1.0.2'
+
   
 end


### PR DESCRIPTION
- Podspec changes to pick the latest version of razporpay-core-pod
- Removed the [exclude_arch] to support arm64 simulator architecture. 