### PR TITLE
Swift Package manifest for the `2.2.0` SPM release. [ CBXC-32 ]

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 
-let packageVersion = "1.5.0"
+let packageVersion = "2.2.0"
 
 
 let package = Package(
@@ -47,25 +47,25 @@ let package = Package(
 
         .binaryTarget(
             name: "Razorpay",
-            url: "https://github.com/razorpay/razorpay-customui-pod/releases/download/1.5.0/Razorpay.xcframework.zip",
+            url: "https://github.com/razorpay/razorpay-customui-pod/releases/download/2.2.0/Razorpay.xcframework.zip",
             checksum: "a51208d8529b813e4625829f2fd0624651f1c4113f61507636096d6756284ba7"
         ),
 
         .binaryTarget(
             name: "RazorpayCustom",
-            url: "https://github.com/razorpay/razorpay-customui-pod/releases/download/1.5.0/RazorpayCustom.xcframework.zip",
+            url: "https://github.com/razorpay/razorpay-customui-pod/releases/download/2.2.0/RazorpayCustom.xcframework.zip",
             checksum: "ba359c81870950f7f5dee5bc1f539adb028efe482335104d242bcc64ac59d021"
         ),
 
         .binaryTarget(
             name: "RazorpayCore",
-            url: "https://github.com/razorpay/razorpay-customui-pod/releases/download/1.5.0/RazorpayCore.xcframework.zip",
+            url: "https://github.com/razorpay/razorpay-customui-pod/releases/download/2.2.0/RazorpayCore.xcframework.zip",
             checksum: "43905538520d5a74f3316567c5ecff945075ccd0e09ae38bb9b3de8f194272de"
         ),
 
         .binaryTarget(
             name: "RazorpayApplePay",
-            url: "https://github.com/razorpay/razorpay-customui-pod/releases/download/1.5.0/RazorpayApplePay.xcframework.zip",
+            url: "https://github.com/razorpay/razorpay-customui-pod/releases/download/2.2.0/RazorpayApplePay.xcframework.zip",
             checksum: "c9e47f4e3edaee208f910ea4626b733da0767102768f8b0d806824ee84f62568"
         ),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 
-let packageVersion = "1.4.1"
+let packageVersion = "1.5.0"
 
 
 let package = Package(
@@ -16,18 +16,58 @@ let package = Package(
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "RazorpayCustomUI",
-            targets: ["RazorpayWrapper"]
+            targets: [
+                "RazorpayCustomUI",
+                "Razorpay",
+                "RazorpayCustom",
+                "RazorpayCore",
+                "RazorpayApplePay"
+            ]
+        ),
+        .library(
+            name: "RazorpayApplePay",
+            targets: [
+                "RazorpayApplePay",
+                "Razorpay",
+                "RazorpayCustom",
+                "RazorpayCore"
+            ]
         ),
     ],
     targets: [
-       .binaryTarget(
-            name: "Razorpay",
-            path: "Pod/Razorpay.xcframework"
+       .target(
+            name: "RazorpayCustomUI",
+            dependencies: [
+                .target(name: "Razorpay"),
+                .target(name: "RazorpayCore"),
+                .target(name: "RazorpayCustom"),
+            ],
+            path: "sources/RazorpayWrapper"
         ),
-        .target(
-            name: "RazorpayWrapper",
-            dependencies: ["Razorpay"]
-        )
+
+        .binaryTarget(
+            name: "Razorpay",
+            url: "https://github.com/razorpay/razorpay-customui-pod/releases/download/1.5.0/Razorpay.xcframework.zip",
+            checksum: "a51208d8529b813e4625829f2fd0624651f1c4113f61507636096d6756284ba7"
+        ),
+
+        .binaryTarget(
+            name: "RazorpayCustom",
+            url: "https://github.com/razorpay/razorpay-customui-pod/releases/download/1.5.0/RazorpayCustom.xcframework.zip",
+            checksum: "ba359c81870950f7f5dee5bc1f539adb028efe482335104d242bcc64ac59d021"
+        ),
+
+        .binaryTarget(
+            name: "RazorpayCore",
+            url: "https://github.com/razorpay/razorpay-customui-pod/releases/download/1.5.0/RazorpayCore.xcframework.zip",
+            checksum: "43905538520d5a74f3316567c5ecff945075ccd0e09ae38bb9b3de8f194272de"
+        ),
+
+        .binaryTarget(
+            name: "RazorpayApplePay",
+            url: "https://github.com/razorpay/razorpay-customui-pod/releases/download/1.5.0/RazorpayApplePay.xcframework.zip",
+            checksum: "c9e47f4e3edaee208f910ea4626b733da0767102768f8b0d806824ee84f62568"
+        ),
     ],
     swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
## Summary

This PR updates the Swift Package manifest for the `2.2.0` SPM release.

Compared to `master`, this changes `Package.swift` to:

- Publish package version metadata as `2.2.0`
- Replace the local binary target path:
  - from `Pod/Razorpay.xcframework`
  - to remote GitHub release binary targets
- Add remote binary targets for:
  - `Razorpay`
  - `RazorpayCustom`
  - `RazorpayCore`
  - `RazorpayApplePay`
- Expose two library products:
  - `RazorpayCustomUI`
  - `RazorpayApplePay`

## Validation

Ran:

```bash
swift package dump-package