### PR TITLE
fix(ci): release notes body cleanup done by CI

### DIFF
--- a/.github/workflows/deploy-core-release.yml
+++ b/.github/workflows/deploy-core-release.yml
@@ -413,6 +413,7 @@ jobs:
         run: |
           set -eo pipefail
 
+          # Release is created with an empty body (no auto-generated notes).
           HTTP_STATUS=$(curl --silent --output /tmp/core_release_create.json --write-out "%{http_code}" \
             -X POST \
             -H "Authorization: Bearer ${CI_BOT_TOKEN}" \
@@ -422,9 +423,7 @@ jobs:
               --arg tag_name "${TAG_NAME}" \
               --arg name "Core ${VERSION}" \
               --arg target "${MERGE_COMMIT_SHA}" \
-              --argjson prerelease false \
-              --argjson generate_release_notes true \
-              '{tag_name: $tag_name, name: $name, target_commitish: $target, prerelease: $prerelease, generate_release_notes: $generate_release_notes}')")
+              '{tag_name: $tag_name, name: $name, target_commitish: $target, prerelease: false, body: ""}')")
 
           if [ "$HTTP_STATUS" -eq 201 ]; then
             echo "✅ Core GitHub Release created"

--- a/.github/workflows/deploy-custom-checkout.yml
+++ b/.github/workflows/deploy-custom-checkout.yml
@@ -527,6 +527,7 @@ jobs:
             IS_PRERELEASE="true"
           fi
 
+          # Release is created with an empty body (no auto-generated notes).
           HTTP_STATUS=$(curl --silent --output /tmp/customui_release.json --write-out "%{http_code}" \
             -X POST \
             -H "Authorization: Bearer ${CI_BOT_TOKEN}" \
@@ -537,8 +538,7 @@ jobs:
               --arg name "Custom Checkout ${VERSION}" \
               --arg target "${MERGE_COMMIT_SHA}" \
               --argjson prerelease ${IS_PRERELEASE} \
-              --argjson generate_release_notes true \
-              '{tag_name: $tag_name, name: $name, target_commitish: $target, prerelease: $prerelease, generate_release_notes: $generate_release_notes}')")
+              '{tag_name: $tag_name, name: $name, target_commitish: $target, prerelease: $prerelease, body: ""}')")
 
           if [ "$HTTP_STATUS" -eq 201 ]; then
             echo "✅ Custom Checkout GitHub Release created"


### PR DESCRIPTION
This pr changes the release body content made through `deploy-custom-checkout.yml` and `deploy-core-release.yml` which was earlier autogenerated release notes.